### PR TITLE
Freeze setup.py versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,12 @@ setup(name='pantheonrl',
       packages=find_packages(),
       include_package_data=True,
       install_requires=[
-        'flask',
-        'tensorflow',
-        'torch',
-        'tensorboard',
-        'stable-baselines3',
-        'scipy',
-        'tqdm'
+        'flask==2.2.2',
+        'tensorflow==2.11.0',
+        'torch==1.13.1',
+        'tensorboard==2.11.0',
+        'stable-baselines3==1.7.0',
+        'scipy==1.7.3',
+        'tqdm==4.64.1'
       ],
       )


### PR DESCRIPTION
This repository's README instructions do not work due to package stable-baselines3's v2 update since the last repository fix in January 10, 2023. All other packages were frozen to versions on or before January 10, 2023 (or if not available in Python 3.7, the latest version).